### PR TITLE
Unity taggers don't need to be loaded for Razor files

### DIFF
--- a/src/CSInlineColorViz.Tests/UnityTaggerTests.cs
+++ b/src/CSInlineColorViz.Tests/UnityTaggerTests.cs
@@ -82,6 +82,24 @@ public class UnityTaggerTests : BaseTaggerTests
 	}
 
 	[TestMethod]
+	public void CanMatchSingleColor_Name_InDoubleQuotes()
+	{
+		var sut = new UnityTextTagger(new FakeTextBuffer());
+
+		Assert.IsNotNull(sut);
+
+		var lineWithColor = "<Color=\"\"Purple\"\">";
+
+		var matches = sut.ColorExpression.Matches(lineWithColor).Cast<Match>();
+
+		Assert.AreEqual(1, matches.Count());
+
+		var tag = sut.TryCreateTagForMatch(matches.First(), 0, 0, 0, lineWithColor);
+
+		Assert.IsNotNull(tag);
+	}
+
+	[TestMethod]
 	public void CanMatchSingleColor_Name_CheckGeneratedTagValues()
 	{
 		var sut = new UnityTextTagger(new FakeTextBuffer());

--- a/src/ColorRgbaTagger.cs
+++ b/src/ColorRgbaTagger.cs
@@ -6,7 +6,6 @@ using WpfColorHelper;
 
 namespace CsInlineColorViz;
 
-// TODO: might be good to combine this with ColorRgbTagger
 internal sealed class ColorRgbaTagger : RegexTagger<ColorTag>, ITestableRegexColorTagger
 {
 	internal static Regex regularExpression = new(@"(Color.FromRgba\()([0-9, ]{7,})(\))", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);

--- a/src/UnityTaggerProvider.cs
+++ b/src/UnityTaggerProvider.cs
@@ -8,8 +8,6 @@ namespace CsInlineColorViz;
 
 [Export(typeof(ITaggerProvider))]
 [ContentType("CSharp")]
-[ContentType("Razor")]
-[ContentType("LegacyRazorCSharp")]
 [TagType(typeof(ColorTag))]
 internal sealed class UnityTaggerProvider : ITaggerProvider
 {

--- a/src/UnityTextTagger.cs
+++ b/src/UnityTextTagger.cs
@@ -7,7 +7,7 @@ namespace CsInlineColorViz;
 
 internal sealed class UnityTextTagger : RegexTagger<ColorTag>, ITestableRegexColorTagger
 {
-	internal static Regex regularExpression = new(@"(<Color=)([\\]{0,1}[""]{0,1})([a-z]{3,})(?=[\\]{0,1}[""]{0,1}>)", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+	internal static Regex regularExpression = new(@"(<Color=)([\\]{0,1}[""]{0,2})([a-z]{3,})(?=[\\]{0,1}[""]{0,2}>)", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
 	public Regex ColorExpression => regularExpression;
 

--- a/src/UnityTextTaggerProvider.cs
+++ b/src/UnityTextTaggerProvider.cs
@@ -8,8 +8,6 @@ namespace CsInlineColorViz;
 
 [Export(typeof(ITaggerProvider))]
 [ContentType("CSharp")]
-[ContentType("Razor")]
-[ContentType("LegacyRazorCSharp")]
 [TagType(typeof(ColorTag))]
 internal sealed class UnityTextTaggerProvider : ITaggerProvider
 {


### PR DESCRIPTION
- Unity taggers don't need to be loaded for Razor files
- Support Unity color names in Double quotes
- Remove possible TODO - separating RGB & RGBA